### PR TITLE
Enhance project API with contributor and activity counts

### DIFF
--- a/api/src/project/repository.ts
+++ b/api/src/project/repository.ts
@@ -2,6 +2,8 @@ import { eq, ne, sql } from "drizzle-orm";
 import { camelCaseObject } from "src/_utils/case";
 import { unStringifyDeep } from "src/_utils/unstringify-deep";
 import { repositoriesTable } from "src/repository/table";
+import { contributionsTable } from "src/contribution/table";
+import { contributorsTable } from "src/contributor/table";
 import { SQLiteService } from "src/sqlite/service";
 import { Service } from "typedi";
 
@@ -20,18 +22,30 @@ export class ProjectRepository {
         p.slug as slug,
         json_group_array(
             json_object('id', r.id, 'owner', r.owner, 'name', r.name)
-        ) AS repositories
+        ) AS repositories,
+        COUNT(DISTINCT c.contributor_id) AS contributors_count,
+        SUM(c.activity_count) AS activity_count,
+        MAX(repo_activities.repo_activity_count) as max_repo_activity_count
     FROM
         ${projectsTable} p
-    JOIN
+    LEFT JOIN
         ${repositoriesTable} r ON p.id = r.project_id
+    LEFT JOIN
+        ${contributionsTable} c ON r.id = c.repository_id
+    LEFT JOIN
+        (SELECT repository_id, SUM(activity_count) as repo_activity_count FROM ${contributionsTable} GROUP BY repository_id) repo_activities ON r.id = repo_activities.repository_id
     GROUP BY
         p.id;
     `;
     const raw = this.sqliteService.db.all(statement);
     const unStringifiedRaw = unStringifyDeep(raw);
     const camelCased = camelCaseObject(unStringifiedRaw);
-    return camelCased;
+    const scored = camelCased.map((p) => ({
+      ...p,
+      score: (p.maxRepoActivityCount || 0) + (p.contributorsCount || 0),
+    }));
+    const sorted = scored.sort((a, b) => b.score - a.score);
+    return sorted;
   }
 
   public async upsert(project: ProjectRow) {

--- a/api/src/project/types.ts
+++ b/api/src/project/types.ts
@@ -6,6 +6,9 @@ export interface GetProjectsResponse extends GeneralResponse {
   projects: Array<
     Pick<ProjectEntity, "id" | "name" | "slug"> & {
       repositories: Array<Pick<RepositoryEntity, "id" | "owner" | "name">>;
+      contributorsCount: number;
+      activityCount: number;
+      score: number;
     }
   >;
 }


### PR DESCRIPTION
This PR enhances the `GetProjects` API to provide more comprehensive project insights and enable prioritized listing.

It adds `contributorsCount` (total unique contributors) and `activityCount` (total activity across all repositories) to each project. A `score` is calculated for each project, defined as the sum of its highest repository's activity count and its total contributors. Projects are then sorted by this score in descending order, presenting the most active and contributed projects first.

This allows users to quickly identify and prioritize projects based on their overall engagement and activity.

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

---
<a href="https://cursor.com/background-agent?bcId=bc-018a5eca-38dc-485a-b0d5-ebac0919b336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-018a5eca-38dc-485a-b0d5-ebac0919b336">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

